### PR TITLE
GNOME Shell 3.32 support

### DIFF
--- a/mprisindicatorbutton@JasonLG1979.github.io/extension.js
+++ b/mprisindicatorbutton@JasonLG1979.github.io/extension.js
@@ -392,9 +392,10 @@ class Player extends PopupMenu.PopupBaseMenuItem {
     }
 }
 
+var MprisIndicatorButton = GObject.registerClass(
 class MprisIndicatorButton extends PanelMenu.Button {
-    constructor() {
-        super(0.0, "Mpris Indicator Button", false);
+    _init() {
+        super._init(0.0, "Mpris Indicator Button", false);
         this.actor.accessible_name = "Mpris";
         this.menu.actor.add_style_class_name("aggregate-menu");
         this.menu.box.set_layout_manager(new Panel.AggregateLayout());
@@ -541,4 +542,4 @@ class MprisIndicatorButton extends PanelMenu.Button {
         }
         super._onEvent(actor, event);
     }
-}
+});

--- a/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
+++ b/mprisindicatorbutton@JasonLG1979.github.io/metadata.json
@@ -3,6 +3,6 @@
 "name": "Mpris Indicator Button",
 "description": "A simple MPRIS indicator button.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.30"],
+"shell-version": ["3.32"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extensions-mpris-indicator-button/"
 }


### PR DESCRIPTION
This pull request addresses #2.
Be aware that changes required to make this extension work on 3.32 break it for 3.30 with the following error:
`Extension "mprisindicatorbutton@JasonLG1979.github.io" had error: TypeError: GObject.registerClass() used with in valid base class (is PanelMenuButton)`